### PR TITLE
Predictions Over Http

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,6 @@ services:
       - GUNICORN_CMD_ARGS=--reload
     volumes:
       - ./server/:/app
-      - images:/app/images
       - training_results:/app/training_results
     ports:
       - "5000:5000"
@@ -37,7 +36,6 @@ services:
       dockerfile: Dockerfile
     volumes:
       - ./server/:/app
-      - images:/app/images
       - training_results:/app/training_results
     environment:
       - GUNICORN_CMD_ARGS=--reload
@@ -47,5 +45,4 @@ services:
 
 volumes:
   db_container:
-  images:
   training_results:

--- a/server/dependency.py
+++ b/server/dependency.py
@@ -80,7 +80,7 @@ class MicroserviceConnection(BaseModel):
     """
 
     name: str = Field(alias="modelName")
-    port: int = Field(alias="modelPort")
+    socket: str = Field(alias="modelSocket")
 
     class Config:
         allow_population_by_field_name = True

--- a/server/images/README.md
+++ b/server/images/README.md
@@ -1,5 +1,0 @@
-## Docker Volume Image Storage
-Images will be generated in this folder via Docker in the volume named `photoanalysisserver_images`.
-
-Do not manually add images to this directory. Instead, use the endpoints in the server to add
-images to this directory.

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -16,5 +16,6 @@ imagehash
 aiofiles
 Sphinx
 sphinx_rtd_theme
+glob2
 pytest
 pytest-timeout

--- a/server/test/test_prediction.py
+++ b/server/test/test_prediction.py
@@ -9,37 +9,9 @@ from main import app
 
 client = TestClient(app)
 
-# from https://fastapi.tiangolo.com/advanced/testing-dependencies/
-# not clear if this is needed (come back after monorepo is created)
-#
-# async def override_dependency():
-#     return get_user_by_name_db('testing')
-
-# app.dependency_overrides[current_user_investigator] = override_dependency
-
-@pytest.mark.timeout(5)
-def test_get_all_prediction_models():
-
-    # Predict on images
-    # needs dependency?
-    register_model = client.post("/model/all")
-    assert register_model.status_code == 200
-
-@pytest.mark.timeout(5)
-def test_predict_on_images():
-
-    #read files from docker container (add file path)
-    upload_files = [(file, open(file), "image/jpeg") for file in glob.glob("/app/<file_path>/*")]
-
-    #pass arguments
-    args= {"images":upload_files, 
-            "models":["example_model"]
-    }
-
-    # Predict on images
-    predict_on_images = client.post("/model/predict", params=args)
-    print("STATUS", predict_on_images)
-    assert predict_on_images.status_code == 200
+# --------------
+# Working Tests
+# --------------
 
 @pytest.mark.timeout(5)
 def test_register_model():
@@ -52,5 +24,42 @@ def test_register_model():
     # Predict on images
     register_model = client.post("/model/register", json=mlmicroservice_object)
     assert register_model.status_code == 200
+    
+    
+# --------------
+# Failing Tests
+# --------------
+
+# from https://fastapi.tiangolo.com/advanced/testing-dependencies/
+# not clear if this is needed (come back after monorepo is created)
+#
+# async def override_dependency():
+#     return get_user_by_name_db('testing')
+
+# app.dependency_overrides[current_user_investigator] = override_dependency
+
+# @pytest.mark.timeout(5)
+# def test_get_all_prediction_models():
+
+#     # Predict on images
+#     # needs dependency?
+#     register_model = client.post("/model/all")
+#     assert register_model.status_code == 200
+
+# @pytest.mark.timeout(5)
+# def test_predict_on_images():
+
+#     #read files from docker container (add file path)
+#     upload_files = [(file, open(file), "image/jpeg") for file in glob.glob("/app/<file_path>/*")]
+
+#     #pass arguments
+#     args= {"images":upload_files, 
+#             "models":["example_model"]
+#     }
+
+#     # Predict on images
+#     predict_on_images = client.post("/model/predict", params=args)
+#     print("STATUS", predict_on_images)
+#     assert predict_on_images.status_code == 200
 
     

--- a/server/test/test_prediction.py
+++ b/server/test/test_prediction.py
@@ -1,5 +1,54 @@
+import pytest
 from fastapi.testclient import TestClient
+import glob
+from main import app
+from fastapi import Depends
+from db_connection import get_user_by_name_db
 
 from main import app
 
 client = TestClient(app)
+
+# from https://fastapi.tiangolo.com/advanced/testing-dependencies/
+# not clear if this is needed (come back after monorepo is created)
+#
+# async def override_dependency():
+#     return get_user_by_name_db('testing')
+
+# app.dependency_overrides[current_user_investigator] = override_dependency
+
+@pytest.mark.timeout(5)
+def test_get_all_prediction_models():
+
+    # Predict on images
+    # needs dependency?
+    register_model = client.post("/model/all")
+    assert register_model.status_code == 200
+
+@pytest.mark.timeout(5)
+def test_predict_on_images():
+
+    #read files from docker container (add file path)
+    upload_files = [(file, open(file), "image/jpeg") for file in glob.glob("/app/<file_path>/*")]
+
+    #pass arguments
+    args= {"images":upload_files, 
+            "models":["example_model"]
+    }
+
+    # Predict on images
+    predict_on_images = client.post("/model/predict", params=args)
+    print("STATUS", predict_on_images)
+    assert predict_on_images.status_code == 200
+
+@pytest.mark.timeout(5)
+def test_register_model():
+
+    #create mlmicroservice object. MLMicroserviceTemplate needs to be running on port 5000
+    mlmicroservice_object={"name": "testing_register", "socket": "http://host.docker.internal:5000"}
+
+    # Predict on images
+    register_model = client.post("/model/register", json=mlmicroservice_object)
+    assert register_model.status_code == 200
+
+    

--- a/server/test/test_prediction.py
+++ b/server/test/test_prediction.py
@@ -44,8 +44,10 @@ def test_predict_on_images():
 @pytest.mark.timeout(5)
 def test_register_model():
 
-    #create mlmicroservice object. MLMicroserviceTemplate needs to be running on port 5000
-    mlmicroservice_object={"name": "testing_register", "socket": "http://host.docker.internal:5000"}
+    # create mlmicroservice object. 
+    # MLMicroserviceTemplate needs to be running on port that mlservice template is running on
+    # can be changed once we have a monorepo
+    mlmicroservice_object={"name": "testing_register", "socket": "http://host.docker.internal:5005"}
 
     # Predict on images
     register_model = client.post("/model/register", json=mlmicroservice_object)


### PR DESCRIPTION
1. Updated predictions so they can run over HTTP. 
     * File is posted to MLMicroservice's `/predict` endpoint
     * It is received as an `UploadFile` object
     * See [predictions-over-http branch](https://github.com/UMass-Rescue/MLMicroserviceTemplate/pull/9) in MLMicroservice for sister code

2. Changed MLMicroservice object to contain a Socket instead of Port
     * Updated all model.py functions that require a port
     * Will be useful for k8 

3. Attempted testing of some model.py functions
     * Registering a model passes the test
     * Getting a list of all models and testing the predict function do not work due to dependency issues
     * To be revisited once a monorepo is created.